### PR TITLE
Refactored #most_accurate and #least accurate

### DIFF
--- a/data/teams_dummy.csv
+++ b/data/teams_dummy.csv
@@ -9,5 +9,5 @@ team_id,franchiseId,teamName,abbreviation,Stadium,link
 17,12,LA Galaxy,LA,Dignity Health Sports Park,/api/v1/teams/17
 18,34,Minnesota United FC,MIN,Allianz Field,/api/v1/teams/18
 19,18,Philadelphia Union,PHI,Talen Energy Stadium,/api/v1/teams/19
-28,29,Los Angeles FC,LFC,Banc of California Stadium,/api/v1/teams/28
+2,22,Seattle Sounders FC,SEA,Centruy Link Field,/api/v1/teams/2
 16,11,New England Revolution,NE,Gillette Stadium,/api/v1/teams/16

--- a/lib/league.rb
+++ b/lib/league.rb
@@ -124,33 +124,36 @@ class League
   end
 
   def most_accurate_team(season)
-    games_by_season = @games.group_by {|game| game.season}
-    games_by_season.keep_if {|key, value| key == season}
-    games_in_season = games_by_season.map {|season, game| game.map {|game| game.game_id}}.flatten
-    games_in_question_array = @game_teams.select {|game| games_in_season}
-    team_id_array = games_in_question_array.map {|game| game.team_id}
+    games_in_question_array = games_played_in_season(season)
+    games_in_question_hash = game_stats_by_team_id(season)
+    goals_by_team_array = games_in_question_hash.map {|key, game| game.map {|stat| stat.goals.to_f}}
+    total_goals = goals_by_team_array.map {|goal| goal.sum}
+    shots_by_team_array = games_in_question_hash.map {|key, game| game.map {|stat| stat.shots.to_f}}
+    total_shots = shots_by_team_array.map {|shot| shot.sum}
 
-    goals = games_in_question_array.map {|game| game.goals.to_f}
-    shots = games_in_question_array.map {|game| game.shots.to_f}
-    ratios_array = goals.zip(shots).map {|thing| thing.inject(:/).round(2)}
-    ratios_by_team = Hash[team_id_array.zip(ratios_array)]
-    max_ratio = ratios_by_team.key(ratios_by_team.values.max)
-    team_name_from_id(max_ratio)
-  end
+    team_id_array = games_in_question_array.map {|game| game.team_id}.uniq
 
-  def least_accurate_team(season)
-    games_by_season = @games.group_by {|game| game.season}
-    games_by_season.keep_if {|key, value| key == season}
-    games_in_season = games_by_season.map {|season, game| game.map {|game| game.game_id}}.flatten
-    games_in_question_array = @game_teams.select {|game| games_in_season}
-    team_id_array = games_in_question_array.map {|game| game.team_id}
-
-    goals = games_in_question_array.map {|game| game.goals.to_f}
-    shots = games_in_question_array.map {|game| game.shots.to_f}
-    ratios_array = goals.zip(shots).map {|thing| thing.inject(:/).round(2)}
+    ratios_array = total_shots.zip(total_goals).map {|thing| thing.inject(:/)}
     ratios_by_team = Hash[team_id_array.zip(ratios_array)]
     min_ratio = ratios_by_team.key(ratios_by_team.values.min)
     team_name_from_id(min_ratio)
+  end
+
+  def least_accurate_team(season)
+    games_in_question_array = games_played_in_season(season)
+    games_in_question_hash = game_stats_by_team_id(season)
+    goals_by_team_array = games_in_question_hash.map {|key, game| game.map {|stat| stat.goals.to_f}}
+    total_goals = goals_by_team_array.map {|goal| goal.sum}
+    shots_by_team_array = games_in_question_hash.map {|key, game| game.map {|stat| stat.shots.to_f}}
+    total_shots = shots_by_team_array.map {|shot| shot.sum}
+
+    team_id_array = games_in_question_array.map {|game| game.team_id}.uniq
+
+    ratios_array = total_goals.zip(total_shots).map {|thing| thing.inject(:/)}
+    ratios_by_team = Hash[team_id_array.zip(ratios_array)]
+    min_ratio = ratios_by_team.key(ratios_by_team.values.min)
+    team_name_from_id(min_ratio)
+    # require "pry"; binding.pry
   end
 
   def team_info(team_id)

--- a/spec/league_spec.rb
+++ b/spec/league_spec.rb
@@ -117,17 +117,17 @@ RSpec.describe League do
   end
   #coach name in game_teams_dummy, season in games_dummy
 
-  xit 'can calculate coach with the worst win percentage' do
+  it 'can calculate coach with the worst win percentage' do
     expect(league.worst_coach("20122013")).to eq("John Tortorella")
     expect(league.worst_coach("20132014")).to eq("John Tortorella")
   end
   #coach name in game_teams_dummy, season in games_dummy
   it 'can calculate the most accurate team' do
-    expect(league.most_accurate_team("20122013")).to eq("FC Dallas")
+    expect(league.most_accurate_team("20122013")).to eq("LA Galaxy")
   end
 
   it 'can calculate the least accurate team' do
-    expect(league.least_accurate_team("20122013")).to eq("Philadelphia Union")
+    expect(league.least_accurate_team("20122013")).to eq("Seattle Sounders FC")
   end
 
   it 'can calculate the most tackles' do

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -130,12 +130,12 @@ RSpec.describe StatTracker do
 
   it 'can calculate the most accurate team' do
 
-    expect(@stat_tracker.most_accurate_team("20122013")).to eq("FC Dallas")
+    expect(@stat_tracker.most_accurate_team("20122013")).to eq("LA Galaxy")
   end
 
   it 'can calculate the least accurate team'do
 
-    expect(@stat_tracker.least_accurate_team("20122013")).to eq("Philadelphia Union")
+    expect(@stat_tracker.least_accurate_team("20122013")).to eq("Seattle Sounders FC")
   end
 
   xit 'can find the team with the most tackles' do


### PR DESCRIPTION
These are now passing the spec harness after deleting the #round(2) method being called in the making of the ratios! 